### PR TITLE
remove linux rocks online from the blocklist

### DIFF
--- a/blocklist
+++ b/blocklist
@@ -77,7 +77,6 @@ lets.bemoe.online
 lets.saynoto.lgbt
 liberdon.com
 ligma.pro
-linuxrocks.online
 liveview.cf
 mastodon.starrevolution.org
 mentality.rip


### PR DESCRIPTION
Signed-off-by: Kris Nóva <kris@nivenly.com>