### PR TITLE
Handling and keeping track of blocked and unblocked servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ Then you can run the scripts!
 A docker compose file makes it handy for you to run it scoped without modifying your environment :
 
 ```bash
-# Run the complete blocklist
+# Update server blocklist and unblocklist
 docker compose up
-# or 
+# or
+domain_update_from_blocklists
+
+# Unblock the complete unblocklist 
 docker compose run hack domain_block_from_blocklist
 
 # Block a specific domain

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
       - .env
     volumes:
       - ./:/usr/local/bin
-    command: domain_block_from_blocklist
+    command: domain_update_from_blocklists

--- a/domain_block
+++ b/domain_block
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
-sh _var.sh
+BASEDIR=$(dirname "$0")
+
+sh $BASEDIR/_var.sh
 
 if [ -z $1 ]; then
   echo "Missing argument. domain_block <domain>"
@@ -8,6 +10,7 @@ fi
 DOMAIN=$1
 
 curl \
+  -w "\n" \
   -X POST \
   -d "domain=${DOMAIN}" \
   --header "Authorization: Bearer ${MASTODON_ACCESS_TOKEN}" \

--- a/domain_block_from_blocklist
+++ b/domain_block_from_blocklist
@@ -1,6 +1,4 @@
 #!/usr/bin/env sh
-sh _var.sh
-
 BASEDIR=$(dirname "$0")
 
 while IFS= read -r d || [ -n "$d" ]; do

--- a/domain_blocks
+++ b/domain_blocks
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
-sh _var.sh
+BASEDIR=$(dirname "$0")
 
-curl --header "Authorization: Bearer ${MASTODON_ACCESS_TOKEN}" -sS \
+sh $BASEDIR/_var.sh
+
+curl \
+  -w "\n" \
+  --header "Authorization: Bearer ${MASTODON_ACCESS_TOKEN}" -sS \
   https://${MASTODON_SERVER}/api/v1/domain_blocks

--- a/domain_unblock
+++ b/domain_unblock
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
-sh _var.sh
+BASEDIR=$(dirname "$0")
 
+sh $BASEDIR/_var.sh
 
 if [ -z $1 ]; then
   echo "Missing argument. domain_unblock <domain>"
@@ -9,6 +10,7 @@ fi
 DOMAIN=$1
 
 curl \
+  -w "\n" \
   -X DELETE \
   -d "domain=${DOMAIN}" \
   --header "Authorization: Bearer ${MASTODON_ACCESS_TOKEN}" \

--- a/domain_unblock_from_unblocklist
+++ b/domain_unblock_from_unblocklist
@@ -1,6 +1,4 @@
 #!/usr/bin/env sh
-sh _var.sh
-
 BASEDIR=$(dirname "$0")
 
 while IFS= read -r d || [ -n "$d" ]; do

--- a/domain_update_from_blocklists
+++ b/domain_update_from_blocklists
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+BASEDIR=$(dirname "$0")
+
+$BASEDIR/domain_block_from_blocklist
+
+$BASEDIR/domain_unblock_from_unblocklist

--- a/oauth_get_token
+++ b/oauth_get_token
@@ -5,6 +5,7 @@ sh _var.sh
 # Difficult to get the redirection to work in CLI, might as well get it from settings for now
 
 authorization_code=curl \
+  -w "\n" \
   -X GET \
   -d "response_type=code" \
   -d "client_id=${MASTODON_CLIENT_KEY}" \
@@ -17,6 +18,7 @@ authorization_code=curl \
 # /TODO push user credentials to website then get returned authorization_code (next command needs to be updated accordingly)
 
 MASTODON_ACCESS_TOKEN=curl \
+  -w "\n" \
   -X POST \
   -d "grant_type=code" \
   -d "client_id=${MASTODON_CLIENT_KEY}" \

--- a/timelines_home
+++ b/timelines_home
@@ -1,4 +1,6 @@
 #!/usr/bin/env shsh _var.sh
 
-curl --header "Authorization: Bearer ${MASTODON_ACCESS_TOKEN}" -sS \
+curl \
+  -w "\n" \
+  --header "Authorization: Bearer ${MASTODON_ACCESS_TOKEN}" -sS \
   https://${MASTODON_SERVER}/api/v1/timelines/home

--- a/unblocklist
+++ b/unblocklist
@@ -1,2 +1,4 @@
 hachyderm.io
+linuxrocks.online
+mastodon.cloud
 mastodon.social


### PR DESCRIPTION
- New script that blocks and unblocks server depending on the list
- Making sure that all those scripts run independent of being called from PWD
- Adding new line to curl response
- Adding linuxrocks.online + mastodon.cloud to the unblock list

I also see you recommend tootctl, if you want to switch to that we can make a scripted update that would fetch info from here and push it through tootctl ? 