### PR TITLE
Add whitesmokebbq.social to blocklist

### DIFF
--- a/blocklist
+++ b/blocklist
@@ -162,6 +162,7 @@ wagesofsinisdeath.com
 waifuappreciation.club
 weedis.life
 wetfish.space
+whitesmokebbq.social
 wolfgirl.bar
 wurm.host
 x0f.org


### PR DESCRIPTION
whitesmokebbq.social is a neo-nazi brand that should be on the blocklist. See the thread https://mastodon.social/@atomicpoet/109312590321474036 for more information.