### PR TITLE
Adding support for auto-retrieval of blocklists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+trusted_blocklists/*
 .idea
 .env

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ docker compose run hack domain_block <domain>
 # Unblock the complete unblocklist
 docker compose run hack domain_unblock_from_unblocklist
 
-# Unblock a specific domain
-docker compose run hack domain_unblock <domain>
+# Retrieve blocklist from a instance
+docker compose run hack retrieve_blocklist <domain>
+
+# Parse the blocking comments from retrieved blocklists and extracts
+# domains based on a list of offending terms. The terms can be regex
+# and are case insensitive. The default behaviour is to just add everything.
+docker compose run hack parse_blocklists list_of_offending_terms [also_block_domains_without_comment]
+
+# Retrieve the blocklists from all trusted peers and updates the
+# blocklist. Only trusted peers (not necessarelly the all the unblocked)
+# are synced.
+docker compose run hack sync_peers_blocklist
 ```

--- a/offending_terms
+++ b/offending_terms
@@ -1,9 +1,0 @@
-nazi
-racis(m|t)
-alt-right
-(homo|trans)phobia
-pedo
-loli
-anti-(semiti(sm|c)|lgbt|enby|nb)
-hate speech
-spam

--- a/offending_terms
+++ b/offending_terms
@@ -1,0 +1,9 @@
+nazi
+racis(m|t)
+alt-right
+(homo|trans)phobia
+pedo
+loli
+anti-(semiti(sm|c)|lgbt|enby|nb)
+hate speech
+spam

--- a/offending_terms.example
+++ b/offending_terms.example
@@ -1,0 +1,9 @@
+nazi
+racis(m|t)
+alt-right
+(homo|trans)phobia
+pedo
+loli
+anti-(semiti(sm|c)|lgbt|enby|nb)
+hate speech
+spam

--- a/parse_blocklists
+++ b/parse_blocklists
@@ -6,14 +6,16 @@ if [ -z $1 ]; then
   echo "Missing argument. parse_blocklist <offending_terms> [<permit_empty_reason>]"
   exit 1
 fi
+
 offending_terms="$1"
 empty_reason="$2"
+
 if [ ${#empty_reason} -ne 0 ]; then
   while IFS= read -r regex || [ -n "$regex" ]; do
     jq -r ".[] | if .comment | length == 0 or test(\"${regex}\"; \"i\") then .domain else empty end" $BASEDIR/trusted_blocklists/*.json
-  done < offending_terms | sort -u
+  done < "${offending_terms}" | sort -u
 else
   while IFS= read -r regex || [ -n "$regex" ]; do
     jq -r ".[] | if .comment | length != 0 and test(\"${regex}\"; \"i\") then .domain else empty end" $BASEDIR/trusted_blocklists/*.json
-  done < offending_terms | sort -u
+  done < "${offending_terms}" | sort -u
 fi

--- a/parse_blocklists
+++ b/parse_blocklists
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+BASEDIR=$(dirname "$0")
+
+if [ -z $1 ]; then
+  echo "Missing argument. parse_blocklist <offending_terms> [<permit_empty_reason>]"
+  exit 1
+fi
+offending_terms="$1"
+empty_reason="$2"
+if [ ${#empty_reason} -ne 0 ]; then
+  while IFS= read -r regex || [ -n "$regex" ]; do
+    jq -r ".[] | if .comment | length == 0 or test(\"${regex}\"; \"i\") then .domain else empty end" $BASEDIR/trusted_blocklists/*.json
+  done < offending_terms | sort -u
+else
+  while IFS= read -r regex || [ -n "$regex" ]; do
+    jq -r ".[] | if .comment | length != 0 and test(\"${regex}\"; \"i\") then .domain else empty end" $BASEDIR/trusted_blocklists/*.json
+  done < offending_terms | sort -u
+fi

--- a/parse_blocklists
+++ b/parse_blocklists
@@ -10,12 +10,16 @@ fi
 offending_terms="$1"
 empty_reason="$2"
 
-if [ ${#empty_reason} -ne 0 ]; then
-  while IFS= read -r regex || [ -n "$regex" ]; do
-    jq -r ".[] | if .comment | length == 0 or test(\"${regex}\"; \"i\") then .domain else empty end" $BASEDIR/trusted_blocklists/*.json
-  done < "${offending_terms}" | sort -u
+if [ -s ${offending_terms} ]; then
+    if [ ${#empty_reason} -ne 0 ]; then
+    while IFS= read -r regex || [ -n "$regex" ]; do
+        jq -r ".[] | if .comment | length == 0 or test(\"${regex}\"; \"i\") then .domain else empty end" $BASEDIR/trusted_blocklists/*.json
+    done < "${offending_terms}" | sort -u
+    else
+    while IFS= read -r regex || [ -n "$regex" ]; do
+        jq -r ".[] | if .comment | length != 0 and test(\"${regex}\"; \"i\") then .domain else empty end" $BASEDIR/trusted_blocklists/*.json
+    done < "${offending_terms}" | sort -u
+    fi
 else
-  while IFS= read -r regex || [ -n "$regex" ]; do
-    jq -r ".[] | if .comment | length != 0 and test(\"${regex}\"; \"i\") then .domain else empty end" $BASEDIR/trusted_blocklists/*.json
-  done < "${offending_terms}" | sort -u
+    jq -r '.[] | .domain' $BASEDIR/trusted_blocklists/*.json | sort -u
 fi

--- a/retrieve_blocklist
+++ b/retrieve_blocklist
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+BASEDIR=$(dirname "$0")
+
+if [ -z $1 ]; then
+  echo "Missing argument. retrieve_blocklist <domain>"
+  exit 1
+fi
+trusted_peer="$1"
+
+curl --header "Accept: application/json" -sS \
+  https://$trusted_peer/api/v1/instance/domain_blocks \
+  | jq 'if keys[0] | type == "number" then . else empty end' \
+  > "$BASEDIR/trusted_blocklists/${trusted_peer}.json"

--- a/retrieve_blocklist
+++ b/retrieve_blocklist
@@ -10,5 +10,4 @@ trusted_peer="$1"
 
 curl --header "Accept: application/json" -sS \
   https://$trusted_peer/api/v1/instance/domain_blocks \
-  | jq 'if keys[0] | type == "number" then . else empty end' \
-  > "$BASEDIR/trusted_blocklists/${trusted_peer}.json"
+  | jq 'if keys[0] | type == "number" then . else empty end'

--- a/sync_peers_blocklist
+++ b/sync_peers_blocklist
@@ -9,7 +9,7 @@ fi
 
 while IFS= read -r d || [ -n "$d" ]; do
   echo "Retrieving blocklist from $d"
-  $BASEDIR/retrieve_blocklist $d
+  $BASEDIR/retrieve_blocklist $d > "$BASEDIR/trusted_blocklists/$d.json"
 done < $BASEDIR/trusted_peers
 
-$BASEDIR/parse_blocklists offending_terms > $BASEDIR/blocklist
+$BASEDIR/parse_blocklists offending_terms | cat blocklist - | sort -u > $BASEDIR/blocklist

--- a/sync_peers_blocklist
+++ b/sync_peers_blocklist
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+sh _var.sh
+
+BASEDIR=$(dirname "$0")
+
+if [ ! -d trusted_blocklists ]; then
+  mkdir -p $BASEDIR/trusted_blocklists
+fi
+
+while IFS= read -r d || [ -n "$d" ]; do
+  echo "Retrieving blocklist from $d"
+  $BASEDIR/retrieve_blocklist $d
+done < $BASEDIR/trusted_peers
+
+parse_blocklists block_reasons > $BASEDIR/blocklist

--- a/sync_peers_blocklist
+++ b/sync_peers_blocklist
@@ -12,4 +12,4 @@ while IFS= read -r d || [ -n "$d" ]; do
   $BASEDIR/retrieve_blocklist $d
 done < $BASEDIR/trusted_peers
 
-parse_blocklists block_reasons > $BASEDIR/blocklist
+$BASEDIR/parse_blocklists offending_terms > $BASEDIR/blocklist

--- a/trusted_peers
+++ b/trusted_peers
@@ -1,0 +1,2 @@
+hachyderm.io
+mastodon.social


### PR DESCRIPTION
Using the new API endpoint for listing blocked peers, available in `v4.0.0`,  we can build a trust network and share blocklists automatically.

The blocking comments of synced blocklists can be parsed to permit more granular control of what and why to block.