### PR TITLE
fix missing newlines in timelines_home

### DIFF
--- a/timelines_home
+++ b/timelines_home
@@ -1,4 +1,6 @@
-#!/usr/bin/env shsh _var.sh
+#!/usr/bin/env sh
+
+sh _var.sh
 
 curl \
   -w "\n" \


### PR DESCRIPTION
In `timelines_home` the `#!/usr/bin/env sh` and `sh _var.sh` are not separated by a newline, so the script won't work.